### PR TITLE
Update homing missile aim logic

### DIFF
--- a/src/homing_missile.rs
+++ b/src/homing_missile.rs
@@ -1,6 +1,7 @@
 use nalgebra::{Vector2, Vector3};
 use nalgebra::base::Unit;
 
+use crate::enemy_group;
 use crate::enemy;
 
 const MAX_MISSILE_VELOCITY: f32 = -10.0;
@@ -41,6 +42,40 @@ impl Missile {
         }
     }
 
+    fn get_closest_enemy(&self, enemy_group: &enemy_group::EnemyGroup) -> Option<enemy::Enemy> {
+        let mut min_distance: f32 = -1.0;
+        let mut closest_enemy: Option<enemy::Enemy> = None;
+
+        for enemy in &enemy_group.enemy_list {
+            let distance_vec = self.position - enemy.position;
+            let distance: f32 = distance_vec[0].powf(2.0) + distance_vec[1].powf(2.0);
+
+            if min_distance == -1.0 {
+                min_distance = distance;
+            }
+            
+            if distance <= min_distance {
+                min_distance = distance;
+                closest_enemy = Some(enemy::Enemy::new(Fec2::new(enemy.position[0], enemy.position[1])));
+            }
+        }
+
+        closest_enemy
+    }
+
+    pub fn update_homing_missile(&mut self, enemies: &enemy_group::EnemyGroup) {
+        let target = self.get_closest_enemy(enemies);
+
+        match target {
+            Some(x) => {
+                self.set_new_position(&x);
+            },
+            None => {
+                self.set_new_position_empty();                
+            }
+        } 
+    }
+
     pub fn set_new_position_empty(&mut self) {
         self.position += self.rotation_vec * self.velocity;
         self.velocity = MAX_MISSILE_VELOCITY.max(self.velocity + self.acceleration);
@@ -54,7 +89,7 @@ impl Missile {
         let current_direction = Unit::new_normalize(fec3ify(self.rotation_vec));
         let rotate_amount = desired_direction.cross(current_direction.as_ref())[2];
 
-        self.rotation += rotate_amount/5.0;
+        self.rotation += rotate_amount;
         self.rotation_vec = vec_from_rotation(self.rotation);
     }
 }

--- a/src/missile_generator.rs
+++ b/src/missile_generator.rs
@@ -40,27 +40,6 @@ impl MissileGenerator {
         }
     }
 
-    fn get_closest_enemy(&self, enemy_group: &enemy_group::EnemyGroup) -> Option<enemy::Enemy> {
-        let mut min_distance: f32 = -1.0;
-        let mut closest_enemy: Option<enemy::Enemy> = None;
-
-        for enemy in &enemy_group.enemy_list {
-            let distance_vec = self.position - enemy.position;
-            let distance: f32 = distance_vec[0].powf(2.0) + distance_vec[1].powf(2.0);
-
-            if min_distance == -1.0 {
-                min_distance = distance;
-            }
-            
-            if distance <= min_distance {
-                min_distance = distance;
-                closest_enemy = Some(enemy::Enemy::new(Fec2::new(enemy.position[0], enemy.position[1])));
-            }
-        }
-
-        closest_enemy
-    }
-
     pub fn add_missile(&mut self) {
         if self.missile_toggle % 2 == 0 {
             let temp_rotation = (PI/2.0) as f32;
@@ -109,20 +88,9 @@ impl MissileGenerator {
     }
 
     fn update_missiles(&mut self, enemies: &enemy_group::EnemyGroup) {
-        let target = self.get_closest_enemy(enemies);
-
-        match target {
-            Some(x) => {
-                for m in self.missile_list.iter_mut() {
-                    m.set_new_position(&x);
-                }
-            },
-            None => {
-                for m in self.missile_list.iter_mut() {
-                    m.set_new_position_empty();
-                }
-            }
-        } 
+        for m in self.missile_list.iter_mut() {
+            m.update_homing_missile(enemies);
+        }
 
         self.missile_list.retain(|missile| 
             missile.position[1] > 0.0


### PR DESCRIPTION
Homing missiles aim based on nearest target to missile, not by closest target to generator